### PR TITLE
Fetch should take context.Context so that multiple fetching can share their context (e.g. Timeout)

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -84,14 +84,11 @@ func TestFetchWithContext(t *testing.T) {
 	s := dummySlowServer(time.Millisecond * 300)
 	defer s.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*750)
-	defer cancel()
-
+	ctx, _ := context.WithTimeout(context.Background(), time.Millisecond*500)
 	_, err := FetchWithContext(ctx, s.URL)
 	Expect(t, err).ToBe(nil)
 
-	FetchWithContext(ctx, s.URL)
-
+	ctx, _ = context.WithTimeout(context.Background(), time.Millisecond*100)
 	_, err = FetchWithContext(ctx, s.URL)
 	Expect(t, err).Match(context.DeadlineExceeded.Error())
 }

--- a/all_test.go
+++ b/all_test.go
@@ -2,12 +2,15 @@ package opengraph
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/otiai10/marmoset"
 	. "github.com/otiai10/mint"
@@ -77,6 +80,22 @@ func TestFetch_03(t *testing.T) {
 	Expect(t, og.Image[0].URL).ToBe("http://www-cdn.jtvnw.net/images/twitch_logo3.jpg")
 }
 
+func TestFetchWithContext(t *testing.T) {
+	s := dummySlowServer(time.Millisecond * 300)
+	defer s.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*750)
+	defer cancel()
+
+	_, err := FetchWithContext(ctx, s.URL)
+	Expect(t, err).ToBe(nil)
+
+	FetchWithContext(ctx, s.URL)
+
+	_, err = FetchWithContext(ctx, s.URL)
+	Expect(t, err).Match(context.DeadlineExceeded.Error())
+}
+
 func dummyServer(id int) *httptest.Server {
 	marmoset.LoadViews("./test/html")
 	r := marmoset.NewRouter()
@@ -87,4 +106,13 @@ func dummyServer(id int) *httptest.Server {
 		w.WriteHeader(http.StatusNotFound)
 	})
 	return httptest.NewServer(r)
+}
+
+func dummySlowServer(d time.Duration) *httptest.Server {
+	var h = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(d)
+		t, _ := template.ParseFiles("./test/html/02.html")
+		t.Execute(w, nil)
+	})
+	return httptest.NewServer(h)
 }


### PR DESCRIPTION
Timeout and cancellation of a fetch process can be controlled as below.

```go
ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
og, err := opengraph.FetchWithContext(ctx, "https://github.com/otiai10")
```

I wanted to get this feature to be contained in the existing `Fetch()`, but the function structure did not allow it and I did not come up with a better way than adding `FetchWithContext()`.

More importantly, I'm afraid this requires Go 1.7 or higher as `WithContext()` was introduced in that version.