### PR TITLE
Use <title> as a last resort, not an override

### DIFF
--- a/tag_title.go
+++ b/tag_title.go
@@ -18,7 +18,7 @@ func TitleTag(n *html.Node) *Title {
 
 // Contribute contributes to OpenGraph
 func (t *Title) Contribute(og *OpenGraph) error {
-	if t.Text != "" {
+	if t.Text == "" {
 		og.Title = t.Text
 	}
 	return nil

--- a/tag_title.go
+++ b/tag_title.go
@@ -18,7 +18,7 @@ func TitleTag(n *html.Node) *Title {
 
 // Contribute contributes to OpenGraph
 func (t *Title) Contribute(og *OpenGraph) error {
-	if t.Text == "" {
+	if og.Title == "" && t.Text != "" {
 		og.Title = t.Text
 	}
 	return nil


### PR DESCRIPTION
I think this is the intention of the code, and certainly works better as the current behavior will override an actual `og:title` tag.