### PR TITLE
Support "og:image:url" property

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -80,6 +80,14 @@ func TestFetch_03(t *testing.T) {
 	Expect(t, og.Image[0].URL).ToBe("http://www-cdn.jtvnw.net/images/twitch_logo3.jpg")
 }
 
+func TestFetch_04(t *testing.T) {
+	s := dummyServer(4)
+	og, err := Fetch(s.URL)
+	Expect(t, err).ToBe(nil)
+	Expect(t, len(og.Image)).ToBe(1)
+	Expect(t, og.Image[0].URL).ToBe("/images/01.png")
+}
+
 func TestFetchWithContext(t *testing.T) {
 	s := dummySlowServer(time.Millisecond * 300)
 	defer s.Close()

--- a/tag_meta.go
+++ b/tag_meta.go
@@ -76,7 +76,7 @@ func (m *Meta) IsDescription() bool {
 
 // IsImage returns if it can be a root of "og:image"
 func (m *Meta) IsImage() bool {
-	return m.Property == "og:image"
+	return m.Property == "og:image" || m.Property == "og:image:url"
 }
 
 // IsImageProperty retuns if it can be a property of "og:image" struct

--- a/test/html/04.html
+++ b/test/html/04.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta property="og:image:url" content="/images/01.png">
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
Hi,

I used this package to https://bosyu.me/
But fail to get "og:image", because this site using "og:image:url" as meta property.

Then I read [doc](https://ogp.me/)  about ogp, and found this,

> The og:image property has some optional structured properties:
> - og:image:url - Identical to og:image.

For example, [this site](http://debug.iframely.com/?uri=https%3A%2F%2Fbosyu.me%2F) seems to support "ogp:image:url".

So I updated code to support "og: image: url".
What do you think ?
