### PR TITLE
map og:url property

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -61,13 +61,15 @@ func TestFetch_02(t *testing.T) {
 	Expect(t, err).ToBe(nil)
 	Expect(t, og.Title).ToBe("はいさいナイト")
 	Expect(t, og.Description).ToBe("All Genre Music Party")
+	Expect(t, og.URL.Value).ToBe("https://haisai.party/")
 
 	b := bytes.NewBuffer(nil)
 	json.NewEncoder(b).Encode(og)
 	Expect(t, strings.Trim(b.String(), "\n")).ToBe(fmt.Sprintf(
-		`{"Policy":{"TrustedTags":["meta","link","title"]},"Title":"はいさいナイト","Type":"website","URL":{"Source":"%s","Scheme":"http","Opaque":"","User":null,"Host":"%s","Path":"","RawPath":"","ForceQuery":false,"RawQuery":"","Fragment":""},"SiteName":"","Image":[],"Video":[],"Audio":[],"Description":"All Genre Music Party","Determiner":"","Locale":"","LocaleAlt":[],"Favicon":"/favicon.ico"}`,
+		`{"Policy":{"TrustedTags":["meta","link","title"]},"Title":"はいさいナイト","Type":"website","URL":{"Source":"%s","Scheme":"http","Opaque":"","User":null,"Host":"%s","Path":"","RawPath":"","ForceQuery":false,"RawQuery":"","Fragment":"","Value":"%s"},"SiteName":"","Image":[],"Video":[],"Audio":[],"Description":"All Genre Music Party","Determiner":"","Locale":"","LocaleAlt":[],"Favicon":"/favicon.ico"}`,
 		s.URL,
 		strings.Replace(s.URL, "http://", "", -1),
+		og.URL.Value,
 	))
 }
 

--- a/opengraph.go
+++ b/opengraph.go
@@ -63,6 +63,8 @@ type OpenGraph struct {
 type URL struct {
 	Source string
 	*url.URL
+
+	Value string
 }
 
 // New creates new OpenGraph struct with specified URL.

--- a/tag_meta.go
+++ b/tag_meta.go
@@ -55,6 +55,8 @@ func (m *Meta) Contribute(og *OpenGraph) error {
 		}
 	case m.IsType():
 		og.Type = m.Content
+	case m.IsURL():
+		og.URL.Value = m.Content
 	}
 	return nil
 }
@@ -92,4 +94,9 @@ func (m *Meta) IsType() bool {
 // IsSiteName returns if it can be "og:site_name"
 func (m *Meta) IsSiteName() bool {
 	return m.Property == "og:site_name"
+}
+
+// IsURL returns if it can be "og:url"
+func (m *Meta) IsURL() bool {
+	return m.Property == "og:url"
 }


### PR DESCRIPTION
Issue https://github.com/otiai10/opengraph/issues/11

**What it does:**
- Adds a new field URL.`Value` in Opengraph struct.
- Maps `og:url` property to URL.`Value`, if found.
- Fixes affected tests