### PR TITLE
Properly handle protocol-relative paths

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -157,6 +157,17 @@ func TestOpenGraph_ToAbs(t *testing.T) {
 	u, err = url.Parse(ogp.Audio[0].URL)
 	Expect(t, err).ToBe(nil)
 	Expect(t, u.IsAbs()).ToBe(true)
+
+	ogp = New(testserver.URL + "/case/03_image")
+	err = ogp.Fetch()
+	Expect(t, err).ToBe(nil)
+	err = ogp.ToAbs()
+	Expect(t, err).ToBe(nil)
+	u, err = url.Parse(ogp.Image[0].URL)
+	Expect(t, err).ToBe(nil)
+	Expect(t, u.IsAbs()).ToBe(true)
+	Expect(t, u.Host).ToBe("www-cdn.jtvnw.net")
+	Expect(t, u.Path).ToBe("/images/twitch_logo3.jpg")
 }
 
 // This server is ONLY for testing.

--- a/opengraph.go
+++ b/opengraph.go
@@ -79,7 +79,6 @@ func Fetch(url string, intent ...Intent) (*OpenGraph, error) {
 
 // Fetch ...
 func (og *OpenGraph) Fetch() error {
-
 	if og.Intent.URL == "" {
 		return fmt.Errorf("no URL given yet")
 	}
@@ -143,7 +142,6 @@ func (og *OpenGraph) Walk(node *html.Node) error {
 }
 
 func (og *OpenGraph) walk(node *html.Node) error {
-
 	if node.Type == html.ElementNode {
 		switch {
 		case node.Data == HTMLMetaTag && og.trust(node.Data):
@@ -205,6 +203,9 @@ func (og *OpenGraph) joinToAbsolute(base *url.URL, relpath string) string {
 	src, err := url.Parse(relpath)
 	if err == nil && src.IsAbs() {
 		return src.String()
+	}
+	if strings.HasPrefix(relpath, "//") {
+		return fmt.Sprintf("%s:%s", base.Scheme, relpath)
 	}
 	if strings.HasPrefix(relpath, "/") {
 		return fmt.Sprintf("%s://%s%s", base.Scheme, base.Host, relpath)


### PR DESCRIPTION
Currently, calling `ToAbs()` will incorrectly handle protocol-relative URLs and append the entire URL to the base hostname. There's actually an example of this in the test files already, but the case wasn't being tested. This fixes the handling of protocol relative URLs, which are quite common.