### PR TITLE
Fix duplicate media when both root and `*:url` are present

### DIFF
--- a/meta.go
+++ b/meta.go
@@ -42,7 +42,9 @@ func (meta *Meta) Contribute(og *OpenGraph) (err error) {
 	case meta.IsSiteName():
 		og.SiteName = meta.Content
 	case meta.IsImage():
-		og.Image = append(og.Image, Image{URL: meta.Content})
+		if len(og.Image) == 0 || og.Image[len(og.Image)-1].URL != meta.Content {
+			og.Image = append(og.Image, Image{URL: meta.Content})
+		}
 	case meta.IsPropertyOf("og:image"):
 		if len(og.Image) == 0 {
 			return nil
@@ -54,9 +56,13 @@ func (meta *Meta) Contribute(og *OpenGraph) (err error) {
 			og.Image[len(og.Image)-1].Height, err = strconv.Atoi(meta.Content)
 		}
 	case meta.IsAudio():
-		og.Audio = append(og.Audio, Audio{URL: meta.Content})
+		if len(og.Audio) == 0 || og.Audio[len(og.Audio)-1].URL != meta.Content {
+			og.Audio = append(og.Audio, Audio{URL: meta.Content})
+		}
 	case meta.IsVideo():
-		og.Video = append(og.Video, Video{URL: meta.Content})
+		if len(og.Video) == 0 || og.Video[len(og.Video)-1].URL != meta.Content {
+			og.Video = append(og.Video, Video{URL: meta.Content})
+		}
 	case meta.IsPropertyOf("og:video"):
 		if len(og.Video) == 0 {
 			return nil

--- a/test/html/05_video.html
+++ b/test/html/05_video.html
@@ -13,6 +13,7 @@
     <meta property="og:description"
         content="Proximity - End of the Year Mix 2020 (Best of EDM/Gaming/Trap/Dance) Mix made by GhostDragon:https://soundcloud.com/ghostdragonofficialhttps://twitter.com/it...">
     <meta property="og:type" content="video.other">
+    <meta property="og:video" content="https://www.youtube.com/embed/1MxA0i2rxQo">
     <meta property="og:video:url" content="https://www.youtube.com/embed/1MxA0i2rxQo">
     <meta property="og:video:secure_url" content="https://www.youtube.com/embed/1MxA0i2rxQo">
     <meta property="og:video:type" content="text/html">


### PR DESCRIPTION
Some sites define both `og:image,audio,video` as well as the `og:*:url` property. In that case we need to skip adding the media again.
