### PR TITLE
fix: relative path for ToAbs

### DIFF
--- a/opengraph.go
+++ b/opengraph.go
@@ -224,5 +224,9 @@ func (og *OpenGraph) joinToAbsolute(base *url.URL, relpath string) string {
 	if strings.HasPrefix(relpath, "/") {
 		return fmt.Sprintf("%s://%s%s", base.Scheme, base.Host, relpath)
 	}
-	return fmt.Sprintf("%s://%s%s", base.Scheme, base.Host, path.Join(base.Path, relpath))
+	dir := path.Dir(base.Path)
+	if dir == "" || dir == "." {
+		dir = "/"
+	}
+	return fmt.Sprintf("%s://%s%s", base.Scheme, base.Host, path.Join(dir, relpath))
 }

--- a/test/html/06_relative_favicon.html
+++ b/test/html/06_relative_favicon.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta property="og:title" content="Test Relative Favicon" />
+    <meta property="og:url" content="https://example.com/news/article" />
+    <link rel="icon" href="../favicon.svg">
+</head>
+<body>
+    <h1>Test Relative Favicon Resolution</h1>
+</body>
+</html>


### PR DESCRIPTION
ToAbs was not working for relative favicons. This fixes that issue and adds more test coverage